### PR TITLE
Merge staging into main

### DIFF
--- a/test/alerts/GITHUB_WEBHOOK_SETUP.md
+++ b/test/alerts/GITHUB_WEBHOOK_SETUP.md
@@ -100,6 +100,21 @@ git commit -m "Test webhook"
 git push
 ```
 
+## How the Webhook Works
+
+The webhook server processes pushes to specific branches and automatically updates your service:
+
+1. When a push is made to the `main`, `master`, or `staging` branch, GitHub sends a POST request to your webhook server
+2. The server verifies the request signature using your secret
+3. The server checks which branch was pushed to and only processes allowed branches (`main`, `master`, and `staging`)
+4. If valid, it executes the `start.sh update` script which:
+   - Pulls the latest changes from the repository
+   - Installs dependencies and rebuilds the project
+   - Restarts the service using PM2 (if available) or nohup
+5. The server responds with a success message and logs the update process
+
+Pushes to other branches are logged but ignored, allowing you to use feature branches without triggering updates.
+
 ## Step 5: Secure Your Webhook (Optional but Recommended)
 
 For production environments, it's recommended to use HTTPS for your webhook. You can set up Nginx as a reverse proxy with Let's Encrypt SSL certificates:

--- a/test/alerts/GITHUB_WEBHOOK_SETUP.md
+++ b/test/alerts/GITHUB_WEBHOOK_SETUP.md
@@ -102,18 +102,19 @@ git push
 
 ## How the Webhook Works
 
-The webhook server processes pushes to specific branches and automatically updates your service:
+The webhook server intelligently processes pushes and automatically updates your service:
 
-1. When a push is made to the `main`, `master`, or `staging` branch, GitHub sends a POST request to your webhook server
+1. When a push is made to any branch, GitHub sends a POST request to your webhook server
 2. The server verifies the request signature using your secret
-3. The server checks which branch was pushed to and only processes allowed branches (`main`, `master`, and `staging`)
-4. If valid, it executes the `start.sh update` script which:
+3. The server determines the current branch of your local repository
+4. The server checks if the pushed branch matches the current branch of your repository
+5. If they match, it executes the `start.sh webhook-update` script which:
    - Pulls the latest changes from the repository
    - Installs dependencies and rebuilds the project
-   - Restarts the service using PM2 (if available) or nohup
-5. The server responds with a success message and logs the update process
+   - Updates the code without restarting the service (to avoid restart loops)
+6. The server responds with a success message and logs the update process
 
-Pushes to other branches are logged but ignored, allowing you to use feature branches without triggering updates.
+This approach ensures that your service is only updated when changes are pushed to the branch you're currently using, allowing you to safely work with multiple branches without triggering unwanted updates.
 
 ## Step 5: Secure Your Webhook (Optional but Recommended)
 

--- a/test/alerts/README.md
+++ b/test/alerts/README.md
@@ -65,8 +65,8 @@ npm run build
 ### Service Management
 
 ```bash
-# Start the service (uses PM2 if available, falls back to nohup)
-npm start
+# Start the service with PM2 (if available, falls back to nohup)
+npm run start:pm2
 
 # Update the repository and restart the service
 npm run update
@@ -139,12 +139,9 @@ Quick setup:
 2. Start the service:
    ```bash
    # Start the service (uses PM2 if available)
-   npm start
+   npm run start:pm2
 
-   # Start the service without sending Slack notifications
-   npm start -- --skip-slack
-
-   # Or start only the webhook server
+   # Start only the webhook server
    npm run start:webhook
    ```
 

--- a/test/alerts/package.json
+++ b/test/alerts/package.json
@@ -7,7 +7,7 @@
     "build": "tsc",
     "dev": "ts-node src/index.ts",
     "test": "jest",
-    "start": "./start.sh start",
+    "start:pm2": "./start.sh start",
     "update": "./start.sh update",
     "start:dev": "node dist/index.js",
     "start:webhook": "node dist/index.js --webhook-only",

--- a/test/alerts/src/webhook.ts
+++ b/test/alerts/src/webhook.ts
@@ -52,16 +52,22 @@ function handleWebhook(
       // Parse payload
       const webhookData = JSON.parse(payload.toString()) as WebhookPayload
 
-      // Only process pushes to the main branch
-      if (
-        webhookData.ref !== 'refs/heads/main' &&
-        webhookData.ref !== 'refs/heads/master'
-      ) {
+      // Only process pushes to the main, master, or staging branches
+      const allowedBranches = ['main', 'master', 'staging']
+      const branchName = webhookData.ref.replace('refs/heads/', '')
+
+      if (!allowedBranches.includes(branchName)) {
         console.log(`Ignoring push to ${webhookData.ref}`)
         res.statusCode = 200
-        res.end('Ignored non-main branch push')
+        res.end(
+          `Ignored push to ${branchName} branch. Only ${allowedBranches.join(
+            ', '
+          )} branches are processed.`
+        )
         return
       }
+
+      console.log(`Processing push to ${branchName} branch`)
 
       console.log(`Received valid webhook from ${webhookData.pusher.name}`)
       console.log(`Repository: ${webhookData.repository.full_name}`)

--- a/test/alerts/src/webhook.ts
+++ b/test/alerts/src/webhook.ts
@@ -1,4 +1,4 @@
-import { exec } from 'child_process'
+import { exec, execSync } from 'child_process'
 import crypto from 'crypto'
 import fs from 'fs'
 import http from 'http'
@@ -52,22 +52,42 @@ function handleWebhook(
       // Parse payload
       const webhookData = JSON.parse(payload.toString()) as WebhookPayload
 
-      // Only process pushes to the main, master, or staging branches
-      const allowedBranches = ['main', 'master', 'staging']
+      // Get the branch name from the webhook data
       const branchName = webhookData.ref.replace('refs/heads/', '')
 
-      if (!allowedBranches.includes(branchName)) {
-        console.log(`Ignoring push to ${webhookData.ref}`)
+      // Get the current branch of the repository
+      const getCurrentBranch = () => {
+        try {
+          // Execute git command to get current branch
+          const currentBranch = execSync(
+            `cd ${config.repoPath} && git rev-parse --abbrev-ref HEAD`,
+            { encoding: 'utf8' }
+          ).trim()
+          return currentBranch
+        } catch (error) {
+          console.error('Error getting current branch:', error)
+          // Default to main if we can't determine the current branch
+          return 'main'
+        }
+      }
+
+      const currentBranch = getCurrentBranch()
+
+      // Only process pushes to the current branch
+      if (branchName !== currentBranch) {
+        console.log(
+          `Ignoring push to ${branchName} branch (current branch is ${currentBranch})`
+        )
         res.statusCode = 200
         res.end(
-          `Ignored push to ${branchName} branch. Only ${allowedBranches.join(
-            ', '
-          )} branches are processed.`
+          `Ignored push to ${branchName} branch. Only pushes to the current branch (${currentBranch}) are processed.`
         )
         return
       }
 
-      console.log(`Processing push to ${branchName} branch`)
+      console.log(
+        `Processing push to ${branchName} branch (matches current branch)`
+      )
 
       console.log(`Received valid webhook from ${webhookData.pusher.name}`)
       console.log(`Repository: ${webhookData.repository.full_name}`)
@@ -76,9 +96,9 @@ function handleWebhook(
       // Execute update script
       const scriptPath = path.join(config.repoPath, 'test/alerts/start.sh')
       console.log('Executing update script...')
-      // Use npm run update if the script exists, otherwise fall back to direct execution
+      // Use webhook-update command to avoid restart loops
       const updateCommand = fs.existsSync(scriptPath)
-        ? `${scriptPath} update`
+        ? `${scriptPath} webhook-update`
         : 'npm run update'
 
       console.log(`Running command: ${updateCommand}`)


### PR DESCRIPTION
This pull request introduces several improvements to the webhook functionality, service management, and update process for the `test/alerts` project. Key changes include enhancing the webhook's branch handling logic, introducing a new `webhook-update` mode to avoid restart loops, and refining service start commands to better support PM2. These updates aim to increase reliability, flexibility, and maintainability of the system.

### Webhook Enhancements:
* Added logic in `test/alerts/src/webhook.ts` to dynamically determine the current branch of the repository and process pushes only for the active branch, improving multi-branch support.
* Updated webhook documentation in `test/alerts/GITHUB_WEBHOOK_SETUP.md` to explain how the webhook processes pushes and avoids unnecessary updates.

### Service Management Updates:
* Replaced `npm start` with `npm run start:pm2` in `test/alerts/README.md` and `test/alerts/package.json` to explicitly use PM2 for service management, ensuring better compatibility and avoiding recursive script calls. [[1]](diffhunk://#diff-2984a5df8a18722a1fcb1bb7e568bccd9b9286eb3cda450fae8595e04a775235L68-R69) [[2]](diffhunk://#diff-2984a5df8a18722a1fcb1bb7e568bccd9b9286eb3cda450fae8595e04a775235L142-R144) [[3]](diffhunk://#diff-9f1cdfbfb95ad04140dd2711a911c396fe9bd5c75c161d87a7c5bd9d9fa8d7efL10-R10)

### Update Process Improvements:
* Introduced a `webhook-update` mode in `test/alerts/start.sh` to allow repository updates without restarting the service, preventing restart loops during webhook-triggered updates.
* Added a `build_project` function in `test/alerts/start.sh` to ensure the project is rebuilt before starting or restarting the service, improving consistency after updates.

### Codebase Enhancements:
* Added `execSync` import in `test/alerts/src/webhook.ts` to enable synchronous execution of shell commands for retrieving the current branch.