### PR TITLE
fix: correct search endpoint schema and example

### DIFF
--- a/subnets/42/api.yml
+++ b/subnets/42/api.yml
@@ -3,6 +3,8 @@ endpoints:
   - path: /search
     externalPath: /v1/search/live/twitter
     method: POST
+    summary: "Initiate an asynchronous Twitter search job (Subnet 42)"
+    description: "Starts a job on Bittensor Subnet 42 to search Twitter based on a query (supports advanced operators). Returns a job UUID which can be used to check status and retrieve results later. Specify 'max_results' to limit tweet count."
     auth:
       type: header
       key: "Authorization"
@@ -12,20 +14,38 @@ endpoints:
     requestSchema:
       type: object
       properties:
-        query:
+        type:
           type: string
-          description: "Twitter search query. Supports advanced operators like 'from:user', 'since:YYYY-MM-DD'"
-        max_results:
-          type: integer
-          description: "Maximum number of tweets to return (up to 100 per request)"
-          default: 100
-          minimum: 1
-          maximum: 100
-      required: [query]
+          description: "Data source type. 'twitter-scraper' uses API or credentials, 'twitter-api-scraper' uses API only, 'twitter-credential-scraper' uses credentials only."
+          enum: ["twitter-scraper", "twitter-api-scraper", "twitter-credential-scraper"]
+          default: "twitter-scraper"
+        arguments:
+          type: object
+          description: "Arguments specific to the search type."
+          properties:
+            type:
+              type: string
+              description: "Search method: 'searchbyquery' for live tweets, 'searchbyfullarchive' for historical tweets."
+              enum: ["searchbyquery", "searchbyfullarchive"]
+              default: "searchbyquery"
+            query:
+              type: string
+              description: "Twitter search query. Supports advanced operators like 'from:user', 'since:YYYY-MM-DD'"
+              default: ""
+            max_results:
+              type: integer
+              description: "Maximum number of tweets to return (up to 100 for live, 500 for archive)"
+              default: 100 # Default for live search
+              minimum: 1
+              maximum: 500 # Max for archive search
+          required: [type, query] # Type and query required within arguments
+      required: [type, arguments] # Top-level type and arguments object are required
 
   - path: /status
     externalPath: /v1/search/live/twitter/status/{jobUUID}
     method: GET
+    summary: "Check the status of a Twitter search job (Subnet 42)"
+    description: "Retrieves the current status (e.g., pending, running, completed, failed) of an asynchronous Twitter search job initiated on Subnet 42, using the job's unique UUID."
     auth:
       type: header
       key: "Authorization"
@@ -38,6 +58,8 @@ endpoints:
   - path: /result
     externalPath: /v1/search/live/twitter/result/{jobUUID}
     method: GET
+    summary: "Get the results of a completed Twitter search job (Subnet 42)"
+    description: "Retrieves the collected tweets from a completed asynchronous Twitter search job on Subnet 42, using the job's unique UUID. Only works if the job status is 'completed'."
     auth:
       type: header
       key: "Authorization"

--- a/subnets/42/examples/search/request.json
+++ b/subnets/42/examples/search/request.json
@@ -1,4 +1,8 @@
 {
-  "query": "AI trending",
-  "max_results": 10
+  "type": "twitter-scraper",
+  "arguments": {
+    "type": "searchbyquery",
+    "query": "AI trending",
+    "max_results": 10
+  }
 }


### PR DESCRIPTION
This pull request enhances the API for Subnet 42's Twitter search functionality by adding detailed documentation, expanding request schema options, and updating example request payloads. These changes improve usability, clarity, and flexibility for developers using the API.

### API Documentation Enhancements:
* Added `summary` and `description` fields for the `/search`, `/status`, and `/result` endpoints to provide clear explanations of their purpose and usage. [[1]](diffhunk://#diff-14a63f8f56c5d98b07ea585e186e7d44de775f684d9c016a30dd22a1fef84644R6-R7) [[2]](diffhunk://#diff-14a63f8f56c5d98b07ea585e186e7d44de775f684d9c016a30dd22a1fef84644R61-R62)

### Request Schema Updates:
* Introduced a new `type` field in the request schema to specify the data source type (`twitter-scraper`, `twitter-api-scraper`, or `twitter-credential-scraper`) with a default value of `twitter-scraper`.
* Added an `arguments` object to the schema, which includes a nested `type` field for search methods (`searchbyquery` or `searchbyfullarchive`) and updated constraints for `query` and `max_results` fields (e.g., increased `max_results` to 500 for archive searches).

### Example Payload Update:
* Updated the example request payload in `subnets/42/examples/search/request.json` to include the new `type` and `arguments` fields, demonstrating the updated schema.